### PR TITLE
Added new required fields for training object (#97)

### DIFF
--- a/force-app/main/default/objects/Training__c/fields/BatchDuration__c.field-meta.xml
+++ b/force-app/main/default/objects/Training__c/fields/BatchDuration__c.field-meta.xml
@@ -4,7 +4,7 @@
     <externalId>false</externalId>
     <label>BatchDuration</label>
     <precision>2</precision>
-    <required>false</required>
+    <required>true</required>
     <scale>0</scale>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>

--- a/force-app/main/default/objects/Training__c/fields/ProjectStartDate__c.field-meta.xml
+++ b/force-app/main/default/objects/Training__c/fields/ProjectStartDate__c.field-meta.xml
@@ -4,7 +4,7 @@
     <externalId>false</externalId>
     <inlineHelpText>If no Project Start Date is entered when creating a Training object, this field will default to three weeks before the end date of the training.</inlineHelpText>
     <label>ProjectStartDate</label>
-    <required>false</required>
+    <required>true</required>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
     <type>Date</type>

--- a/force-app/main/default/objects/Training__c/fields/Project__c.field-meta.xml
+++ b/force-app/main/default/objects/Training__c/fields/Project__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Project__c</fullName>
-    <deleteConstraint>SetNull</deleteConstraint>
+    <deleteConstraint>Restrict</deleteConstraint>
     <externalId>false</externalId>
     <label>Project</label>
     <referenceTo>Project__c</referenceTo>
     <relationshipLabel>Trainings</relationshipLabel>
     <relationshipName>Trainings</relationshipName>
-    <required>false</required>
+    <required>true</required>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
     <type>Lookup</type>

--- a/force-app/main/default/objects/Training__c/fields/Room__c.field-meta.xml
+++ b/force-app/main/default/objects/Training__c/fields/Room__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Room__c</fullName>
-    <deleteConstraint>SetNull</deleteConstraint>
+    <deleteConstraint>Restrict</deleteConstraint>
     <externalId>false</externalId>
     <label>Room</label>
     <referenceTo>Room__c</referenceTo>
     <relationshipLabel>Trainings</relationshipLabel>
     <relationshipName>Trainings</relationshipName>
-    <required>false</required>
+    <required>true</required>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
     <type>Lookup</type>


### PR DESCRIPTION
* Added new required fields for training object

Batch duration, project start date

* made room and project required

this is so that all fields that BatchAndProjectTables queries for are required so you can't break the Project Force page by, for example, not adding a location to a new Training__c record