### PR TITLE
fixed error when closing modal

### DIFF
--- a/force-app/main/default/aura/modal/modalHelper.js
+++ b/force-app/main/default/aura/modal/modalHelper.js
@@ -354,7 +354,7 @@
 		var mainComponent = component.find("chartIdThing");
 		$A.util.addClass(modal, 'hideModal');
 		$A.util.removeClass(backdrop, 'slds-backdrop slds-backdrop_open');
-		mainComponent.location.reload();
+		//mainComponent.location.reload(); --useless?
 		return;
 	},
 


### PR DESCRIPTION
Seemingly useless line. 
ChartIDThing refers to a div in NewD3Comp that contains JSChart and the chart info calculations. However:

* The chart info does not ever have a location method or variable.
* Neither JSChart nor Lightning canvas have a reload or location method/variable
* Reloading the location is not necessary for the method to function properly.  